### PR TITLE
Remove Twitter app deep link

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,7 +31,6 @@ const {
 const socialImageURL = new URL(ogImage, Astro.url);
 const isAppsPage =
   Astro.url.pathname === "/apps" || Astro.url.pathname === "/apps/";
-const appStoreURL = "https://apps.apple.com/app/apple-store/id6753172187";
 const appDescription =
   "See your calendar events and reminders at a glance with widgets.";
 
@@ -100,10 +99,10 @@ const structuredData = {
     {isAppsPage ? (
       <>
         <meta name="twitter:card" content="app" />
+        <meta name="twitter:site" content="@_jooheekim_" />
         <meta name="twitter:description" content={appDescription} />
         <meta name="twitter:app:name:iphone" content="I Need That Widget" />
         <meta name="twitter:app:id:iphone" content="6753172187" />
-        <meta name="twitter:app:url:iphone" content={appStoreURL} />
       </>
     ) : (
       <>


### PR DESCRIPTION
## Summary
- remove the Twitter app card deep-link meta tag because we do not need a custom app URL
- add the required Twitter site handle for the app card metadata

## Root cause
`twitter:app:url:iphone` was being used for the App Store URL, but that field is intended for an in-app deep link.

## Validation
- npm run build
- verified `dist/apps/index.html` renders the app card tags without `twitter:app:url:iphone`